### PR TITLE
DEV-474 Implement handling of rebus nftid role config

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,8 @@ DEFAULT_GENERAL_WELCOME_MESSAGE_TITLE="Cosmos Verify Bot"
 DEFAULT_GENERAL_WELCOME_MESSAGE_URL="https://github.com/rebuschain/cosmos.verify.bot"
 # URL of the webapp that will be used to connect the wallet
 WALLET_CONNECT_URL="https://app.rebuschain.com"
+# URL of the rebus blockchain API (TODO: Update to mainnet url once nftid is deployed to mainnet)
+REBUS_API_URL="https://testnet.rebus.money:4317"
 # If set to true, will use the URL above to restrict cors access
 USE_CORS=false
 # Name of the App thats used to determine the base url for the API calls back to this server in the wallet connect webapp

--- a/src/db/initialize-db.ts
+++ b/src/db/initialize-db.ts
@@ -9,7 +9,14 @@ const initializeDB = async () => {
         table.string('contractAddress');
         table.string('categoryChannelId');
         table.string('generalChannelId');
+        table.boolean('disablePrivateMessages');
       });
+  } else {
+    if (!(await pg.schema.hasColumn('server', 'disablePrivateMessages'))) {
+      await pg.schema.table('server', table => {
+        table.boolean('disablePrivateMessages');
+      });
+    }
   }
 
   if (!(await pg.schema.hasTable('role'))) {
@@ -22,7 +29,14 @@ const initializeDB = async () => {
         table.string('tokenId');
         table.decimal('minBalance');
         table.string('metaCondition');
+        table.string('rebusNftid');
       });
+  } else {
+    if (!(await pg.schema.hasColumn('role', 'rebusNftid'))) {
+      await pg.schema.table('role', table => {
+        table.string('rebusNftid');
+      });
+    }
   }
 
   if (!(await pg.schema.hasTable('nonce'))) {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -4,6 +4,7 @@ export type ServerConfig = {
     contractAddress: string | null;
     categoryChannelId: string | null;
     generalChannelId: string | null;
+    disablePrivateMessages: boolean;
 }
 
 export type Role = {
@@ -14,6 +15,7 @@ export type Role = {
     tokenId: string;
     minBalance: string;
     metaCondition: string;
+    rebusNftid: string;
 }
 
 export type Nonce = {

--- a/src/discord/commands/help.ts
+++ b/src/discord/commands/help.ts
@@ -43,10 +43,12 @@ ${formatBulletPointList([
     'min-balance: The minimum balance required for the user to be assigned to the specified role (Setting to less than 0 will make it be removed)',
     `meta-condition: The condition that the meta properties of the NFT must be matched to in order for the user to be assigned to the specified role (Setting to "null" will make it be removed)
     Example: "name === 'Spooky Pet #3462' && !!attributes.find((attr) => attr.trait_type === 'Landscape')"`,
+    `rebus-nftid: The configuration string for the required nftid to be owned by the user (Setting to "null" will make it be removed)
+    Example: "v1,rebus,require-activation" where the first item is the version, second item is the organization, and third item specifies if activation is required`,
 ], 'The updateable properties are:')}`, ephemeral: true });
             break;
         case 'server':
-            interaction.reply({ content: 'Command only available for admin users. It is used to update the configuration of the server. The updateable properties are: "contract-address"', ephemeral: true });
+            interaction.reply({ content: 'Command only available for admin users. It is used to update the configuration of the server. The updateable properties are: "contract-address" and "disablePrivateMessages"', ephemeral: true });
             break;
         default:
             interaction.reply({ content: 'Invalid subcommand', ephemeral: true });

--- a/src/discord/commands/server.ts
+++ b/src/discord/commands/server.ts
@@ -21,6 +21,7 @@ export const data = new SlashCommandBuilder()
 			.setName('update')
 			.setDescription('Updates the configuration for a server')
 			.addStringOption(option => option.setName('contract-address').setDescription('The ERC721 contract address ("null" to remove)'))
+            .addBooleanOption(option => option.setName('disable-private-messages').setDescription('Whether to send private messages to users when they are assigned a role'))
     );
 
 const serverGet = async (interaction: CommandInteraction) => {
@@ -58,6 +59,7 @@ const serverGet = async (interaction: CommandInteraction) => {
 const serverUpdate = async (interaction: CommandInteraction) => {
     let contractAddress = interaction.options.get('contract-address')?.value as string | null;
     contractAddress = contractAddress?.toLowerCase() === 'null' ? null : contractAddress;
+    const disablePrivateMessages = interaction.options.get('disable-private-messages')?.value as boolean | null;
     const serverId = interaction.guild?.id;
     const logInfo = { serverId, contractAddress };
 
@@ -68,7 +70,7 @@ const serverUpdate = async (interaction: CommandInteraction) => {
             await pg.queryBuilder()
                 .from('server')
                 .where('externalId', '=', serverId)
-                .update({ contractAddress });
+                .update({ contractAddress, disablePrivateMessages });
 
             interaction.reply({ content: 'Server configuration has been updated', ephemeral: true });
 

--- a/src/discord/types.ts
+++ b/src/discord/types.ts
@@ -1,0 +1,17 @@
+export enum RebusNftType {
+	None = 0,
+	v1 = 1,
+}
+
+export type RebusNftId = {
+	id_record: {
+		address: string;
+		type: RebusNftType;
+		organization: string;
+		encryption_key: string;
+		metadata: string;
+		document_number: string;
+		id_number: string;
+		active: boolean;
+	};
+};


### PR DESCRIPTION
Implement handling of rebus nftid role config

By using the new role config `rebus-nftid`, it is posible to configure the roles to be added only if the user owns an nftid or if the user owns an nftid and it is activated
A new server config `disable-private-messages` was also added to stop the bot from sending private messages to users whenever a new role is added/removed